### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,7 @@ hs_err_pid*
 
 .DS_Store
 .idea
+.vscode
 *.iws
 *.iml
 *.ipr
-
-


### PR DESCRIPTION
Folder .vscode has been added to the file .gitignore to prevent tracking of git files specific to vscode editor.